### PR TITLE
allow duplicate warnings when using warnings_exist

### DIFF
--- a/Warn.pm
+++ b/Warn.pm
@@ -352,15 +352,18 @@ sub warnings_exist (&$;$) {
                           _to_array_if_necessary( shift() || [] );
     my $testname    = shift;
     my @got_warning = ();
+    my $exp_idx = 0;
     local $SIG{__WARN__} = sub {
         my ($called_from) = caller(0);  # to find out Carping methods
         my $wrn_text=shift;
         my $wrn_rec=_canonical_got_warning($called_from, $wrn_text);
-        foreach my $wrn (@exp_warning) {
-          if (_cmp_got_to_exp_warning_like($wrn_rec,$wrn)) {
-            push @got_warning, $wrn_rec;
-            return;
-          }
+        if (
+          $exp_idx < @exp_warning and
+          _cmp_got_to_exp_warning_like($wrn_rec,$exp_warning[$exp_idx])
+        ) {
+          push @got_warning, $wrn_rec;
+          $exp_idx++;
+          return;
         }
         warn $wrn_text;
     };

--- a/t/warnings_exist.t
+++ b/t/warnings_exist.t
@@ -18,7 +18,7 @@ shift @lines if $lines[0]=~/^TAP version /; #extra line in new TAP
 my @expected=(
 "warn_2 at $file line 12.",
 'ok 1',
-"warn_2 at $file line 17.",
+"warn_1 at $file line 17.",
 'ok 2',
 'ok 3',
 "warn_2 at $file line 26.",

--- a/t/warnings_exist.t
+++ b/t/warnings_exist.t
@@ -18,16 +18,18 @@ shift @lines if $lines[0]=~/^TAP version /; #extra line in new TAP
 my @expected=(
 "warn_2 at $file line 12.",
 'ok 1',
+"warn_2 at $file line 17.",
 'ok 2',
-"warn_2 at $file line 21.",
-'not ok 3',
-"warn_2 at $file line 27.",
-'ok 4',
-"warn_2 at $file line 31.",
-'not ok 5',
-qr/^Use of uninitialized value (?:\$a\s+)?in addition \(\+\) at \Q$file\E line 36\.$/,
-'ok 6',
-'1..6'
+'ok 3',
+"warn_2 at $file line 26.",
+'not ok 4',
+"warn_2 at $file line 32.",
+'ok 5',
+"warn_2 at $file line 36.",
+'not ok 6',
+qr/^Use of uninitialized value (?:\$a\s+)?in addition \(\+\) at \Q$file\E line 41\.$/,
+'ok 7',
+'1..7'
 );
 foreach my $i (0..$#expected) {
   if ($expected[$i]=~/^\(\?\^?\w*-?\w*:/) {

--- a/t/warnings_exist1.pl
+++ b/t/warnings_exist1.pl
@@ -15,6 +15,11 @@ warnings_exist {
 warnings_exist {
   warn "warn_1";
   warn "warn_2";
+} [qr/warn_1/];
+
+warnings_exist {
+  warn "warn_1";
+  warn "warn_2";
 } [qr/warn_1/,qr/warn_2/];
 
 warnings_exist {

--- a/t/warnings_exist1.pl
+++ b/t/warnings_exist1.pl
@@ -14,7 +14,7 @@ warnings_exist {
 
 warnings_exist {
   warn "warn_1";
-  warn "warn_2";
+  warn "warn_1";
 } [qr/warn_1/];
 
 warnings_exist {


### PR DESCRIPTION
Hello,

In the current implementation, the following tests fail:

https://github.com/hanfried/test-warn/blob/6ffa959961b082e4269cd8444437e7bfeb0fe9c1/t/warnings_exist1.pl#L15-L18

Since `warn_1` **exists**, it seems more natural for this test to pass. This PR check the expected warns in order, not all of them so that this test will pass.

Note that e86c96f694f748aa597a73929c218786234ffa17 is just a preparation, and the change I really want to make is 6ffa959961b082e4269cd8444437e7bfeb0fe9c1 .